### PR TITLE
Use the correct property name

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports = (function store() {
     var storage = require('window.name')
       , koekje = require('koekje');
 
-    return storage.support ? storage : (koekje.supported ? koekje : {
+    return storage.supported ? storage : (koekje.supported ? koekje : {
       length: 0,
       getItem: nope, setItem: nope, removeItem: nope, clear: nope
     });


### PR DESCRIPTION
This fixes an issue that prevented the `window.name` fallback from being used.
