### PR TITLE
Directly return the `sessionStorage` object when available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,15 @@
 language: node_js
 node_js:
+  - "4"
+  - "iojs"
   - "0.12"
-  - "0.11"
   - "0.10"
-  - "0.9"
-  - "0.8"
-  - "iojs-v1.1"
-  - "iojs-v1.0"
-before_install:
-  - "npm install -g npm@1.4.x"
 script:
   - "npm run test-travis"
 after_script:
-  - "npm install coveralls@2.11.x && cat coverage/lcov.info | coveralls"
+  - "npm install coveralls@2 && cat coverage/lcov.info | coveralls"
 matrix:
   fast_finish: true
-  allow_failures:
-    - node_js: "0.11"
-    - node_js: "0.9"
-    - node_js: "iojs-v1.1"
-    - node_js: "iojs-v1.0"
 notifications:
   irc:
     channels:

--- a/index.js
+++ b/index.js
@@ -4,8 +4,7 @@ module.exports = (function store() {
   function nope() { /* Fallback for when no store is supported */ }
 
   try {
-    sessionStorage.setItem('foo', 'bar');
-    if (sessionStorage.getItem('foo') !== 'bar') throw 1;
+    return sessionStorage;
   } catch (e) {
     var storage = require('window.name')
       , koekje = require('koekje');
@@ -15,6 +14,4 @@ module.exports = (function store() {
       getItem: nope, setItem: nope, removeItem: nope, clear: nope
     });
   }
-
-  return sessionStorage;
 }());

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "main": "index.js",
   "scripts": {
     "100%": "istanbul check-coverage --statements 100 --functions 100 --lines 100 --branches 100",
-    "test": "mocha test.js",
+    "test-travis": "istanbul cover _mocha --report lcovonly -- test.js",
+    "coverage": "istanbul cover _mocha -- test.js",
     "watch": "mocha --watch test.js",
-    "coverage": "istanbul cover ./node_modules/.bin/_mocha -- test.js",
-    "test-travis": "istanbul cover node_modules/.bin/_mocha --report lcovonly -- test.js"
+    "test": "mocha test.js"
   },
   "repository": {
     "type": "git",
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/unshiftio/sessionstorage",
   "devDependencies": {
     "assume": "1.3.x",
-    "istanbul": "0.3.x",
+    "istanbul": "0.4.x",
     "mocha": "2.3.x",
     "pre-commit": "1.1.x"
   },


### PR DESCRIPTION
I think that when the `sessionStorage` object is available we can return it immediately without testing if it works properly, so we don't have to clean it up.

See #2.
